### PR TITLE
Fixed typographical error, changed auxilary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SMT chip and associated analog antenna circuitry. Thhe interface to the Bob is v
 Due to a bug on the revision of the AS3935, the Arduino 'Wire' library could not be used. A bing-bang approach using
 the TBD library was used. The bug prevents ready access to register 0 as the chip NAKs the read address cycle.
 The application uses a library for the I2C interface as well as one for the AS3935 specific functions. The code
-provides periodinc tuning of the antenna circuit as well as built-in-test is an auxilary spark generator is 
+provides periodinc tuning of the antenna circuit as well as built-in-test is an auxiliary spark generator is 
 connected to the system. 
 
 The principle output of the Arduino is a serial data stream that contains strings that can be parsed by a host PC to 


### PR DESCRIPTION
SkyeSweeney, I've corrected a typographical error in the documentation of the [Striker](https://github.com/SkyeSweeney/Striker) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
